### PR TITLE
Allow WASI logging through RUST_LOG env var

### DIFF
--- a/src/dev.js
+++ b/src/dev.js
@@ -234,8 +234,9 @@ port = ${opts.ipfsPort}
 
   execa('homestar', ['start', '-c', config1, '--db', db1], {
     preferLocal: true,
+    stdio: 'inherit',
     env: {
-      RUST_LOG: 'none',
+      RUST_LOG: 'off,homestar_wasm=info',
     },
   })
 


### PR DESCRIPTION
This PR  sets the `RUST_LOG` environment variable for Homestar to allow WASI logging messages.
